### PR TITLE
fix: allow mixed turbo/q8_0 KV cache types in CUDA flash-attention selection

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -469,9 +469,33 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
 #ifndef GGML_CUDA_FA_ALL_QUANTS
     if (K->type != V->type) {
-        return BEST_FATTN_KERNEL_NONE;
+        // Allow the mixed KV type pairs that have FA template instances compiled in:
+        // every turbo2/3/4 combination with q8_0 or f16 (turbo KV cache work).
+        auto is_turbo = [](ggml_type t) {
+            return t == GGML_TYPE_TURBO2_0 || t == GGML_TYPE_TURBO3_0 || t == GGML_TYPE_TURBO4_0;
+        };
+        auto is_turbo_compat = [&](ggml_type t) {
+            return is_turbo(t) || t == GGML_TYPE_Q8_0 || t == GGML_TYPE_F16;
+        };
+        if (!(is_turbo(K->type) || is_turbo(V->type)) ||
+            !is_turbo_compat(K->type) || !is_turbo_compat(V->type)) {
+            return BEST_FATTN_KERNEL_NONE;
+        }
     }
 #endif // GGML_CUDA_FA_ALL_QUANTS
+
+    // turbo kernels are instantiated only for head dims that are multiples of 64
+    // (turbo4: multiples of 128, matching its block size).
+    {
+        auto turbo_geom_ok = [](ggml_type t, int64_t ne0) {
+            if (t == GGML_TYPE_TURBO2_0 || t == GGML_TYPE_TURBO3_0) return ne0 % 64 == 0;
+            if (t == GGML_TYPE_TURBO4_0) return ne0 % 128 == 0;
+            return true;
+        };
+        if (!turbo_geom_ok(K->type, K->ne[0]) || !turbo_geom_ok(V->type, V->ne[0])) {
+            return BEST_FATTN_KERNEL_NONE;
+        }
+    }
 
     if (!ggml_cuda_fattn_kv_type_supported(K->type) || !ggml_cuda_fattn_kv_type_supported(V->type)) {
         return BEST_FATTN_KERNEL_NONE;

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -500,6 +500,15 @@ static ggml_type ggml_type_from_name(const std::string & s) {
     if (s == "iq4_nl") {
         return GGML_TYPE_IQ4_NL;
     }
+    if (s == "turbo2") {
+        return GGML_TYPE_TURBO2_0;
+    }
+    if (s == "turbo3") {
+        return GGML_TYPE_TURBO3_0;
+    }
+    if (s == "turbo4") {
+        return GGML_TYPE_TURBO4_0;
+    }
 
     return GGML_TYPE_COUNT;
 }


### PR DESCRIPTION
## Problem

With the default build (no `GGML_CUDA_FA_ALL_QUANTS`), CUDA flash-attention kernel selection rejected **any** mixed K/V cache type pair. A turbo KV setup is almost always mixed (`ctk q8_0` + `ctv turbo2/3`), so the FA support probe failed, `fa auto` disabled flash attention, and context creation either refused the quantized V cache outright or fell back to the non-FA path, whose materialized KQ buffer (~8.7 GiB at 128k ctx / ubatch 1024) OOMs before a single token:

```
W resolve_fused_ops: Flash Attention not supported, set to disabled
E llama_init_from_model: ... quantized V cache was requested, but this requires Flash Attention
E ggml_backend_cuda_buffer_type_alloc_buffer: allocating 8710.00 MiB ... out of memory
```

`-fa on` masked the bug (probe skipped), which is why CLI runs passed while every server load failed.

## Fix

- Allow exactly the mixed pairs with compiled FA template instances: turbo2/3/4 against each other, `q8_0`, and `f16`. All other mixes stay rejected as before.
- Gate turbo head-dim geometry (multiples of 64; 128 for turbo4) so shapes without a compiled instance report unsupported instead of asserting at dispatch.
- llama-bench: accept `turbo2/3/4` in `-ctk`/`-ctv` (its private type-name table predated the turbo types).

Prefill takes the same dequant-to-F16 MMA path as q8_0, so there is no turbo-specific prefill cost.

## Verified — RTX 3060, Qwen3.6-35B-A3B Q4_K_M, `-ncmoe 26 -fa 1 -ctk q8_0`

| ctv | pp2048 t/s | tg64 t/s |
|---|---|---|
| q8_0 | 527.6 | 49.1 |
| turbo2 | 525.8 | 49.2 |

Exact previously-failing config (fa auto, ubatch 1024, ctx 128000, ctk q8_0 + ctv turbo2) now loads with FA enabled and generates correctly.