### PR TITLE
feat: wire MoE expert cache into laguna graph

### DIFF
--- a/src/models/laguna.cpp
+++ b/src/models/laguna.cpp
@@ -286,7 +286,10 @@ llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_para
                     hparams.expert_weights_norm,
                     hparams.expert_weights_scale,
                     (llama_expert_gating_func_type) hparams.expert_gating_func,
-                    il);
+                    il,
+                    nullptr, nullptr,
+                    nullptr, nullptr, nullptr,
+                    nullptr, &model.layers[il]);
             cb(moe_out, "ffn_moe_out", il);
 
             // Always-on shared expert, summed in parallel.


### PR DESCRIPTION
Enables the expert cache for the laguna architecture (118B-A8B). Same one-line call-site wiring as deepseek2; the FFN shape (fused SILU, separate gate/up/down, no expert biases) is fully guard-compatible.

Measured on RTX 3060 (IQ4_XS, ub 128): baseline 48.34 pp256 / 11.50 tg32 → 54.14 (+12%) / 12.10 (+5.2%) with `--moe-cache-slots 36` and n-cpu-moe 99. Oversized slot counts degrade cleanly to baseline (verified).