### PR TITLE
moe-cache: pick a GPU device explicitly instead of the first non-meta device

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1705,7 +1705,24 @@ void llama_model_base::init_moe_expert_cache() {
 
     ggml_backend_dev_t dev = nullptr;
     for (const auto & d : devices) {
-        if (!d.is_meta) { dev = d.dev; break; }
+        if (!d.is_meta && ggml_backend_dev_type(d.dev) == GGML_BACKEND_DEVICE_TYPE_GPU) { dev = d.dev; break; }
+    }
+    if (dev == nullptr) {
+        // fallback: enumerate every backend registry, including dynamically
+        // loaded ones (e.g. libggml-cuda) absent from the default registry
+        for (size_t r = 0; r < ggml_backend_reg_count() && dev == nullptr; ++r) {
+            auto * reg = ggml_backend_reg_get(r);
+            for (size_t i = 0; i < ggml_backend_reg_dev_count(reg); ++i) {
+                auto * d = ggml_backend_reg_dev_get(reg, i);
+                if (ggml_backend_dev_type(d) == GGML_BACKEND_DEVICE_TYPE_GPU) { dev = d; break; }
+            }
+        }
+        if (dev == nullptr) {
+            for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+                auto * d = ggml_backend_dev_get(i);
+                if (ggml_backend_dev_type(d) == GGML_BACKEND_DEVICE_TYPE_GPU) { dev = d; break; }
+            }
+        }
     }
     if (dev == nullptr || ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_GPU) {
         LLAMA_LOG_WARN("%s: no GPU device - expert cache disabled\n", __func__);


### PR DESCRIPTION
## Problem

On hosts where the model device list starts with the CPU device, the expert cache silently disabled itself with `no GPU device - expert cache disabled`, because `init_moe_expert_cache()` picked the **first non-meta** device regardless of its type.

While investigating I also hit two cases where the model device list contains no GPU entry at all (early loading stages / mmap path), so a registry fallback is included.

## Fix

* select the first **GPU-typed** device from the model list
* fall back to enumerating every backend **registry** (including dynamically loaded ones such as `libggml-cuda`) and then the default device registry

## Measured

RTX 5080 Laptop 16 GB, Ornith-1.5-35B-A3B (`qwen35moe`, 41 blocks) Q4_K_M, built with CUDA arch 120:

```
-ngl 99 -ncmoe 99 -fa 1 -c 4096
--moe-cache-profile ornith35-merged.csv --moe-cache-slots 176   (9.78 GiB pack)
```

| config | decode |
|---|---|
| baseline (no cache) | 56.8 tok/s |
| cache, 176 slots | 80.0–86.4 tok/s |
| cache, 176 slots (short bench) | 92.0 tok/s |

That is **+41–62%** on the same hardware, bit-identical outputs, with a single slot count that fits VRAM (40 layers × 176 slots ≈ 9.8 GiB).

The routing profile was captured with `llama-moe-trace` (512-token code + chat prompts, merged) exactly as documented in the README.

Thanks for the great work on this fork — the video walkthrough of the LRU-vs-static tradeoff is excellent.